### PR TITLE
Add reCAPTCHA spam protection to the contact form

### DIFF
--- a/_includes/contact-form.html
+++ b/_includes/contact-form.html
@@ -1,4 +1,15 @@
-  <form action="https://getform.io/f/22dedaf5-8ca1-4dcc-b4b9-f26da1cdb6bf" method="POST">
+<script src="https://www.google.com/recaptcha/api.js?render=6Ldmw-IdAAAAABA8Kr3niHRaIYOYfQ95_9guzhMM"></script>
+
+<script>
+   grecaptcha.ready(function() {
+       grecaptcha.execute('6Ldmw-IdAAAAABA8Kr3niHRaIYOYfQ95_9guzhMM', {action: 'homepage'})
+       .then(function(token) {
+         document.getElementById('captchaResponse').value = token;
+       });
+     });
+</script>
+
+<form action="https://getform.io/f/22dedaf5-8ca1-4dcc-b4b9-f26da1cdb6bf" method="POST">
     <div class="form-group" style="display: block;">
       <label for="name">Name*:</label>
 	<br>
@@ -19,5 +30,6 @@
 	<br>
 	<textarea name="message" id="subject" class="form-control" required="required" cols="40" rows="5"></textarea>
     </div>
+    <input type="hidden" id="captchaResponse" name="g-recaptcha-response">
     <button type="submit" class="btn btn-primary">Submit</button>
   </form>


### PR DESCRIPTION
Hi guys,

as I set up the Getform form for the contact page, I put my mail to receive notifications about new messages. Whenever there is some message, I forward it to the other team members, so you should have an impression about the number of messages the contact form generates (if I had to guess, maybe one message every month or two?). 

However, aside from useful messages, which I forward, there is a large number of spam messages, which all need to be checked in order to not miss the few useful messages. I'd estimate the number of spam messages to around 4-5 per day lately, over 500 messages in total so far, so it is quite time consuming to deal with them. 

I'd propose to either embed some kind of spam protection or to delete the contact form completely, as we have our issues tracked here on Github. Here's an attempt to set up reCAPTCHA as a spam protection mechanism.